### PR TITLE
Update theme config to be themeColor so it works with Jekyll 3.2.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -31,7 +31,7 @@ codepenUsername:
 # Build settings
 markdown: kramdown
 
-#theme: purple # green, blue, orange, purple, grey
+#themeColor: purple # green, blue, orange, purple, grey
 fixedNav: 'true' # true or false
 
 permalink: /:year/:month/:title

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="t-{{ site.theme }}">
+<html class="t-{{ site.themeColor }}">
   {% include head.html %}
   <body>
     {% include navigation.html %}


### PR DESCRIPTION
GitHub just updated their internal jekyll version, which causes this theme to break since the config variable `theme` is now being used as a first class citizen.

The value `themeColor` compiles correctly. I have a [live demo](http://zazuapp.org/).

Thanks!

https://github.com/blog/2236-github-pages-now-runs-jekyll-3-2

https://jekyllrb.com/docs/themes/
